### PR TITLE
fixed compilation issues

### DIFF
--- a/framework/cmd/server/predict.go
+++ b/framework/cmd/server/predict.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rai-project/tracer"
 	"github.com/rai-project/tracer/jaeger"
 	tracerutils "github.com/rai-project/tracer/utils"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/framework/cmd/server/rlimit.go
+++ b/framework/cmd/server/rlimit.go
@@ -35,7 +35,7 @@ func setMaxFileRLimit() error {
 func init() {
 	config.AfterInit(func() {
 		if err := setMaxFileRLimit(); err != nil {
-			log.WithField(err).Info("cannot set maximum file limit")
+			log.WithField("rlimit", err).Info("cannot set maximum file limit")
 		}
 	})
 }


### PR DESCRIPTION
There were a couple of compile time issues - 

/predict.go:17:2: cobra redeclared as imported package name
	previous declaration at ./predict.go:7:2
./rlimit.go:38:17: not enough arguments in call to log.WithField
	have (error)
	want (string, interface {})

This change fixes those issues. Kindly verify if this is what is desired in the second change.